### PR TITLE
Fix cost computation bug in modelHarness.ts

### DIFF
--- a/packages/magnitude-core/src/ai/modelHarness.ts
+++ b/packages/magnitude-core/src/ai/modelHarness.ts
@@ -129,8 +129,8 @@ export class ModelHarness {
             if (model.includes(name)) {
                 inputTokenCost = costs.inputTokens / 1_000_000;
                 outputTokenCost = costs.outputTokens / 1_000_000;
-                cacheWriteInputTokenCost = costs.cacheReadInputTokens ? costs.cacheReadInputTokens / 1_000_000 : undefined;
-                cacheReadInputTokenCost = costs.cacheWriteInputTokens ? costs.cacheWriteInputTokens / 1_000_000 : undefined;
+                cacheReadInputTokenCost = costs.cacheReadInputTokens ? costs.cacheReadInputTokens / 1_000_000 : undefined;
+                cacheWriteInputTokenCost = costs.cacheWriteInputTokens ? costs.cacheWriteInputTokens / 1_000_000 : undefined;
             }
         }
 


### PR DESCRIPTION
I'm pretty sure that the cost of cache reading is not computed properly in `packages/magnitude-core/src/ai/modelHarness.ts`.

Specifically, the cost of reading and writing are swapped. As reading is more expensive than writing, the costs in `usage` will be larger than the actual costs billed by the model provider

I think this PR should fix it :)