### PR TITLE
Fix AWS Bedrock compatibility on macOS with Retina displays

### DIFF
--- a/packages/magnitude-mcp/README.md
+++ b/packages/magnitude-mcp/README.md
@@ -89,10 +89,10 @@ The MCP can optionally be configured with a different persistent profile directo
         "magnitude-mcp"
       ],
       "env": {
-        "MAGNITUDE_MCP_PROFILE_DIR": "/Users/myuser/.magnitude/profiles/default", 
-        "MAGNITUDE_MCP_STEALTH": "true", 
-        "MAGNITUDE_MCP_VIEWPORT_WIDTH": "1024",
-        "MAGNITUDE_MCP_VIEWPORT_HEIGHT": "728"
+        "MAGNITUDE_MCP_PROFILE_DIR": "/Users/myuser/.magnitude/profiles/default",
+        "MAGNITUDE_MCP_STEALTH": "true",
+        "MAGNITUDE_MCP_VIEWPORT_WIDTH": "950",
+        "MAGNITUDE_MCP_VIEWPORT_HEIGHT": "720"
       }
     }
   }
@@ -100,8 +100,8 @@ The MCP can optionally be configured with a different persistent profile directo
 ```
 - `MAGNITUDE_MCP_PROFILE_DIR`: Stores cookies and local storage so that credentials can be re-used across agents using the MCP (default: `~/.magnitude/profiles/default`)
 - `MAGNITUDE_MCP_STEALTH`: Add extra stealth settings to help with anti-bot detection (default: disabled)
-- `MAGNITUDE_MCP_VIEWPORT_WIDTH`: Override viewport width (default: 1024)
-- `MAGNITUDE_MCP_VIEWPORT_WIDTH`: Override viewport width (default: 728)
+- `MAGNITUDE_MCP_VIEWPORT_WIDTH`: Override viewport width (default: 950)
+- `MAGNITUDE_MCP_VIEWPORT_HEIGHT`: Override viewport height (default: 720)
 
 ## Examples
 
@@ -116,4 +116,38 @@ It's even suitable for non-engineering tasks if you just want an easily accessib
 
 ## Troubleshooting
 
+### Model Compatibility
+
 If the agent model is not Claude Sonnet 4, Sonnet 3.7, Opus 4, Qwen 2.5 VL, or Qwen 3 VL, it will probably not work with this MCP - because the vast majority of models cannot click accurately based on an image alone.
+
+### AWS Bedrock Image Size Errors
+
+When using Claude Code with AWS Bedrock (1M context), you may encounter:
+
+```
+API Error: 400 messages.16.content.1.image.source.base64.data:
+At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels
+```
+
+**Cause:** AWS Bedrock limits images to 2000 pixels per dimension for multi-image requests. On macOS with Retina displays, the default viewport (1024×768) uses 2x device scaling, producing 2048×1536 screenshots that exceed this limit.
+
+**Solution:** Reduce viewport size in your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "magnitude": {
+      "command": "npx",
+      "args": ["magnitude-mcp"],
+      "env": {
+        "MAGNITUDE_MCP_VIEWPORT_WIDTH": "950",
+        "MAGNITUDE_MCP_VIEWPORT_HEIGHT": "720"
+      }
+    }
+  }
+}
+```
+
+**Why this works:** 950px × 2 (Retina scaling) = 1900px < 2000px limit ✅
+
+**Note:** This issue only affects AWS Bedrock. The standard Anthropic API has more lenient image size limits.

--- a/packages/magnitude-mcp/src/index.ts
+++ b/packages/magnitude-mcp/src/index.ts
@@ -18,8 +18,8 @@ import { homedir } from 'os';
 const config = {
     profileDir: process.env.MAGNITUDE_MCP_PROFILE_DIR || path.join(homedir(), '.magnitude', 'profiles', 'default'),
     stealth: !!process.env.MAGNITUDE_MCP_STEALTH,  // Enable stealth mode (shows warning banner but better anti-detection)
-    viewportWidth: parseInt(process.env.MAGNITUDE_MCP_VIEWPORT_WIDTH || '1024'),
-    viewportHeight: parseInt(process.env.MAGNITUDE_MCP_VIEWPORT_HEIGHT || '768'),
+    viewportWidth: parseInt(process.env.MAGNITUDE_MCP_VIEWPORT_WIDTH || '950'),
+    viewportHeight: parseInt(process.env.MAGNITUDE_MCP_VIEWPORT_HEIGHT || '720'),
 };
 
 // Ensure profile directory exists


### PR DESCRIPTION
## Summary

- Reduces default viewport from 1024×768 to 950×720 for AWS Bedrock compatibility
- Fixes documentation typo (VIEWPORT_WIDTH → VIEWPORT_HEIGHT)
- Adds comprehensive troubleshooting section for AWS Bedrock image size errors
- Fixes Issue #144 

## Problem

When using Magnitude MCP with Claude Code (or other agentic coding tools) on AWS Bedrock (1M context) with macOS Retina displays, users encounter API errors:

```
API Error: 400 messages.16.content.1.image.source.base64.data:
At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels
```

**Root Cause:**
- Default viewport: 1024×768
- macOS Retina displays: 2x device scaling
- Resulting screenshot: 2048×1536 pixels
- AWS Bedrock limit: 2000 pixels per dimension
- **Result:** Screenshots exceed limit

## Solution

**1. Safer Default Viewport (950×720)**
- With 2x scaling: 1900×1440 pixels
- Stays under 2000px limit 
- Still reasonable size for most web apps
- Provides 100px safety buffer

**2. Fixed Documentation Typo**
- Line 104 incorrectly documented `MAGNITUDE_MCP_VIEWPORT_WIDTH` twice
- Corrected second instance to `MAGNITUDE_MCP_VIEWPORT_HEIGHT`

**3. Added Troubleshooting Documentation**
- Explains AWS Bedrock image size limits
- Provides clear workaround with example config
- Documents calculation: viewport × device scale = screenshot size

## Test Plan

- [x] Verified new defaults work on macOS with Retina display
- [x] Confirmed 950×720 viewport produces 1900×1440 screenshots (under limit)
- [x] Tested with Claude Code + AWS Bedrock (no more errors)
- [x] Verified users can still override via environment variables
- [x] Confirmed backward compatibility (existing configs unaffected)

## Impact

- **Before:** Users hit errors immediately on AWS Bedrock + macOS
- **After:** Works out-of-the-box with safe defaults
- **Breaking Changes:** None (users can override to old values if desired)

## Additional Context

This issue only affects:
- AWS Bedrock (not standard Anthropic API)
- macOS with Retina displays (2x device scaling)
- Multi-image requests in Claude Code

Standard Anthropic API has more lenient image size limits and is unaffected.