### PR TITLE
feat: expand pipeline to ground pixel coordinates with separate llm

### DIFF
--- a/packages/magnitude-core/baml_src/planner.baml
+++ b/packages/magnitude-core/baml_src/planner.baml
@@ -175,3 +175,30 @@ function QueryMemory(memory: AgentContext, query: string, includeClaudeSpoof: bo
 //         {{ DescribeBrowserExecutionContext(context) }}
 //     "# 
 // }
+
+class GroundedActionList {
+    @@dynamic
+}
+
+function GroundActions(screenshot: image, actions: string) -> GroundedActionList {
+    client GeminiPro
+    prompt #"
+        {{ _.role("system") }}
+        You are a helpful assistant that grounds actions to a screenshot.
+        
+        You will receive a list of actions that need to be executed. Some of these actions may be missing specific coordinates (e.g. they may have generic coordinates like 0,0) but describe what they intend to click/scroll.
+        
+        Your job is to:
+        1. Analyze the screenshot to find the correct elements.
+        2. Update the actions with the precise x,y coordinates based on the screenshot.
+        3. Return the list of grounded actions.
+        
+        {{ ctx.output_format }}
+        
+        {{ _.role("user") }}
+        {{ screenshot }}
+        
+        Actions to ground:
+        {{ actions }}
+    "#
+}

--- a/packages/magnitude-core/src/ai/multiModelHarness.ts
+++ b/packages/magnitude-core/src/ai/multiModelHarness.ts
@@ -67,6 +67,10 @@ export class MultiModelHarness {
         return await this.roles['query'].query(context, query, schema);
     }
 
+    async ground<T>(screenshot: Image, actions: Action[], actionVocabulary: ActionDefinition<T>[]): Promise<Action[]> {
+        return await this.roles['ground'].ground(screenshot, actions, actionVocabulary);
+    }
+
     get numUniqueModels() {
         return this.uniqueModels.length;
     }

--- a/packages/magnitude-core/src/ai/types.ts
+++ b/packages/magnitude-core/src/ai/types.ts
@@ -3,8 +3,8 @@
 //     confidence: number
 // }
 
-export type BrowserAgentRole= 'act' | 'extract' | 'query';
-export const allBrowserAgentRoles: BrowserAgentRole[] = ['act', 'extract', 'query'] as const;
+export type BrowserAgentRole= 'act' | 'extract' | 'query' | 'ground';
+export const allBrowserAgentRoles: BrowserAgentRole[] = ['act', 'extract', 'query', 'ground'] as const;
 
 // Approximately mirrors https://docs.boundaryml.com/ref/llm-client-providers
 export type LLMClient = (AnthropicClient | ClaudeCodeClient | BedrockClient | GoogleAIClient | GoogleVertexClient | OpenAIClient | OpenAIGenericClient | AzureOpenAIClient) &


### PR DESCRIPTION
if a grounding llm is provided, the actions generated by planner are sent through a grounding llm that is better at getting pixel coordinates