### PR TITLE
fix(magnitude-core): fix cumulative token counting in ModelHarness._reportUsage()

### DIFF
--- a/packages/magnitude-core/src/ai/modelHarness.ts
+++ b/packages/magnitude-core/src/ai/modelHarness.ts
@@ -170,8 +170,8 @@ export class ModelHarness {
         this.events.emit('tokensUsed', usage);
         //console.log("Usage:", usage);
 
-        this.prevTotalInputTokens = inputTokens;
-        this.prevTotalOutputTokens = outputTokens;
+        this.prevTotalInputTokens += inputTokens;
+        this.prevTotalOutputTokens += outputTokens;
     }
 
     async partialAct<T>(


### PR DESCRIPTION
## Problem

The `_reportUsage()` method in `ModelHarness` incorrectly tracks cumulative token usage, causing the `tokensUsed` event to emit inflated values.

### Root Cause

In `packages/magnitude-core/src/ai/modelHarness.ts`, the method overwrites previous token counts instead of accumulating them:

typescript
// Current (buggy):

this.prevTotalInputTokens = inputTokens;

this.prevTotalOutputTokens = outputTokens;


// Fixed:

this.prevTotalInputTokens += inputTokens;

this.prevTotalOutputTokens += outputTokens;

