### PR TITLE
feat: add Requesty client options mirroring OpenRouter

### DIFF
--- a/packages/magnitude-core/baml_src/clients.baml
+++ b/packages/magnitude-core/baml_src/clients.baml
@@ -56,6 +56,26 @@ client<llm> GeminiFlash {
     }
 }
 
+client<llm> GeminiProRequesty {
+    provider "openai-generic"
+    options {
+        base_url "https://router.requesty.ai/v1"
+        api_key env.REQUESTY_API_KEY
+        model "google/gemini-2.5-pro"
+        temperature 0.0
+    }
+}
+
+client<llm> GeminiFlashRequesty {
+    provider "openai-generic"
+    options {
+        base_url "https://router.requesty.ai/v1"
+        api_key env.REQUESTY_API_KEY
+        model "google/gemini-2.5-flash"
+        temperature 0.0
+    }
+}
+
 client<llm> GPT {
     provider openai
     options {


### PR DESCRIPTION
This adds Requesty client definitions, mirroring the existing OpenRouter clients in `clients.baml`.

Requesty is an OpenAI-compatible LLM gateway, so the clients use the same `openai-generic` provider as the existing `GeminiProOpenRouter` / `GeminiFlash` clients, pointed at `https://router.requesty.ai/v1` with `REQUESTY_API_KEY`.

Changes:
* `packages/magnitude-core/baml_src/clients.baml`: add `GeminiProRequesty` (model `google/gemini-2.5-pro`) and `GeminiFlashRequesty` (model `google/gemini-2.5-flash`), parallel to the OpenRouter clients.

Verification: I tested the endpoint live before opening this. Chat completions for both `google/gemini-2.5-pro` and `google/gemini-2.5-flash` against `https://router.requesty.ai/v1/chat/completions` returned 200.

Docs: https://requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter clients as closely as possible. Happy to adjust or close it if it is not a fit.
