### PR TITLE
feat(core): enable OpenRouter Claude prompt caching

### DIFF
--- a/.changeset/green-lions-cache.md
+++ b/.changeset/green-lions-cache.md
@@ -1,0 +1,5 @@
+---
+"magnitude-core": minor
+---
+
+Enable prompt caching for Anthropic models routed through OpenRouter.

--- a/packages/magnitude-core/src/agent/index.ts
+++ b/packages/magnitude-core/src/agent/index.ts
@@ -14,7 +14,7 @@ import { ActionDefinition } from "@/actions";
 import { taskActions } from "@/actions/taskActions";
 import { ConnectorInstructions, AgentContext, traceAsync, MultiMediaContentPart } from "@/ai/baml_client";
 import { telemetrifyAgent } from '@/telemetry/events';
-import { isClaude } from '@/ai/util';
+import { isClaude, isOpenRouterClaude } from '@/ai/util';
 import { retryOnError } from '@/common';
 import { renderContentParts } from '@/memory/rendering';
 import { MultiModelHarness } from '@/ai/multiModelHarness';
@@ -101,16 +101,11 @@ export class Agent {
         let doPromptCaching = false;
         for (const client of llms ) {
             // If any LLM is prompt-caching compatible, turn on prompt caching overall for memory etc.
-            if (isClaude(client) && (client.provider === 'anthropic' || client.provider === 'claude-code')) {
+            if ((isClaude(client) && (client.provider === 'anthropic' || client.provider === 'claude-code')) || isOpenRouterClaude(client)) {
                 // Prompt-caching compatible client
-
-                if ('promptCaching' in client.options && client.options.promptCaching !== undefined) {
-                    doPromptCaching = client.options.promptCaching;
-                } else {
-                    // Default to true if not specified, and override on client config to true
-                    doPromptCaching = true;
-                    client.options.promptCaching = true;
-                }
+                const promptCaching = client.options.promptCaching ?? true;
+                client.options.promptCaching = promptCaching;
+                doPromptCaching ||= promptCaching;
             }
         }
 
@@ -123,7 +118,6 @@ export class Agent {
 
         this.memoryOptions = {
             // TODO: maybe do if Gemini or other prompt caching supported providers as well
-            // Claude supports prompt caching but only via Anthropic, not on Bedrock
             promptCaching: doPromptCaching
         };
 

--- a/packages/magnitude-core/src/ai/modelHarness.ts
+++ b/packages/magnitude-core/src/ai/modelHarness.ts
@@ -1,4 +1,4 @@
-import { convertToBamlClientOptions } from "./util";
+import { convertToBamlClientOptions, isOpenRouterClaude } from "./util";
 // Import ModularMemoryContext instead of old MemoryContext
 import { b, AgentContext } from "@/ai/baml_client"; 
 import { Image as BamlImage, Collector, ClientRegistry } from "@boundaryml/baml";
@@ -21,6 +21,21 @@ import { MultiMediaContentPart } from "@/memory/rendering";
 interface ModelHarnessOptions {
     llm: LLMClient;
     //promptCaching?: boolean;
+}
+
+interface OpenRouterUsageResponse {
+    usage?: {
+        prompt_tokens?: unknown;
+        completion_tokens?: unknown;
+        prompt_tokens_details?: {
+            cached_tokens?: unknown;
+            cache_write_tokens?: unknown;
+        };
+    };
+}
+
+function tokenCount(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
 // export interface ModelUsage {
@@ -88,6 +103,7 @@ export class ModelHarness {
         let outputTokens: number = 0;
         let cacheWriteInputTokens: number = 0;
         let cacheReadInputTokens: number = 0;
+        let inputTokenIncrement: number;
 
         if (this.options.llm.provider === 'anthropic' || this.options.llm.provider === 'claude-code') {
             type AnthropicUsage = { input_tokens: number, cache_creation_input_tokens: number, cache_read_input_tokens: number, output_tokens: number, service_tier: string };
@@ -104,10 +120,30 @@ export class ModelHarness {
                 cacheWriteInputTokens = usage.cache_creation_input_tokens;
                 cacheReadInputTokens = usage.cache_read_input_tokens;
             }
-            
+            inputTokenIncrement = inputTokens;
+        } else if (isOpenRouterClaude(this.options.llm)) {
+            const response = this.collector.last?.calls.at(-1)?.httpResponse?.body.json() as OpenRouterUsageResponse | undefined;
+            const promptTokens = tokenCount(response?.usage?.prompt_tokens);
+            if (promptTokens === undefined) {
+                inputTokens = (this.collector.usage.inputTokens ?? 0) - this.prevTotalInputTokens;
+                outputTokens = (this.collector.usage.outputTokens ?? 0) - this.prevTotalOutputTokens;
+                inputTokenIncrement = inputTokens;
+            } else {
+                const details = response?.usage?.prompt_tokens_details;
+                cacheReadInputTokens = Math.min(promptTokens, tokenCount(details?.cached_tokens) ?? 0);
+                cacheWriteInputTokens = Math.min(
+                    promptTokens - cacheReadInputTokens,
+                    tokenCount(details?.cache_write_tokens) ?? 0
+                );
+                inputTokens = promptTokens - cacheReadInputTokens - cacheWriteInputTokens;
+                outputTokens = tokenCount(response?.usage?.completion_tokens) ??
+                    (this.collector.usage.outputTokens ?? 0) - this.prevTotalOutputTokens;
+                inputTokenIncrement = promptTokens;
+            }
         } else {
             inputTokens = (this.collector.usage.inputTokens ?? 0) - this.prevTotalInputTokens;
             outputTokens = (this.collector.usage.outputTokens ?? 0) - this.prevTotalOutputTokens;
+            inputTokenIncrement = inputTokens;
         }
 
         const model = (this.options.llm.options as any).model ?? 'unknown';
@@ -170,7 +206,7 @@ export class ModelHarness {
         this.events.emit('tokensUsed', usage);
         //console.log("Usage:", usage);
 
-        this.prevTotalInputTokens += inputTokens;
+        this.prevTotalInputTokens += inputTokenIncrement;
         this.prevTotalOutputTokens += outputTokens;
     }
 

--- a/packages/magnitude-core/src/ai/promptCaching.test.ts
+++ b/packages/magnitude-core/src/ai/promptCaching.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Agent } from '@/agent';
+import { LLMClient, ModelUsage, OpenAIGenericClient } from '@/ai/types';
+
+import { ModelHarness } from './modelHarness';
+import { convertToBamlClientOptions, isOpenRouterClaude } from './util';
+
+function openRouterClient(overrides: Partial<OpenAIGenericClient['options']> = {}): OpenAIGenericClient {
+    return {
+        provider: 'openai-generic',
+        options: {
+            model: 'anthropic/claude-sonnet-4',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            ...overrides,
+        },
+    };
+}
+
+function memoryPromptCaching(agent: Agent): boolean {
+    return (agent as unknown as { memoryOptions: { promptCaching: boolean } }).memoryOptions.promptCaching;
+}
+
+function setCollector(
+    harness: ModelHarness,
+    responseBody: unknown,
+    collectorUsage: { inputTokens: number; outputTokens: number },
+): { _reportUsage(): void } {
+    const internals = harness as unknown as {
+        collector: {
+            usage: { inputTokens: number; outputTokens: number };
+            last: {
+                calls: Array<{
+                    httpResponse: { body: { json: () => unknown } };
+                }>;
+            };
+        };
+        _reportUsage(): void;
+    };
+    internals.collector = {
+        usage: collectorUsage,
+        last: {
+            calls: [
+                {
+                    httpResponse: { body: { json: () => responseBody } },
+                },
+            ],
+        },
+    };
+    return internals;
+}
+
+function reportUsage(
+    llm: LLMClient,
+    responseBody: unknown,
+    collectorUsage: { inputTokens: number; outputTokens: number },
+): ModelUsage {
+    const harness = new ModelHarness({ llm });
+    let reported: ModelUsage | undefined;
+    harness.events.once('tokensUsed', (usage) => {
+        reported = usage;
+    });
+
+    const internals = setCollector(harness, responseBody, collectorUsage);
+    internals._reportUsage();
+
+    expect(reported).toBeDefined();
+    return reported as ModelUsage;
+}
+
+describe('OpenRouter Claude prompt caching', () => {
+    test('recognizes only the official HTTPS API endpoint', async () => {
+        expect(isOpenRouterClaude(openRouterClient())).toBe(true);
+        expect(isOpenRouterClaude(openRouterClient({ baseUrl: 'https://openrouter.ai/api/v1/' }))).toBe(true);
+
+        for (const baseUrl of [
+            'http://openrouter.ai/api/v1',
+            'https://openrouter.ai.evil.example/api/v1',
+            'https://openrouter.ai/api/v1/extra',
+            'https://user@openrouter.ai/api/v1',
+            'https://openrouter.ai/api/v1?proxy=true',
+            'not a URL',
+        ]) {
+            expect(isOpenRouterClaude(openRouterClient({ baseUrl }))).toBe(false);
+        }
+
+        expect(isOpenRouterClaude(openRouterClient({ model: 'openai/gpt-4.1' }))).toBe(false);
+    });
+
+    test('forwards cache-control metadata by default and preserves client options', async () => {
+        const options = await convertToBamlClientOptions(
+            openRouterClient({
+                apiKey: 'fixture-key',
+                temperature: 0.3,
+                headers: { 'X-Test': 'preserved' },
+            }),
+        );
+
+        expect(options).toMatchObject({
+            base_url: 'https://openrouter.ai/api/v1',
+            api_key: 'fixture-key',
+            model: 'anthropic/claude-sonnet-4',
+            temperature: 0.3,
+            allowed_role_metadata: ['cache_control'],
+            headers: {
+                'HTTP-Referer': 'https://magnitude.run',
+                'X-Title': 'Magnitude',
+                'X-Test': 'preserved',
+            },
+        });
+    });
+
+    test('supports an explicit prompt-caching opt-out', async () => {
+        const client = openRouterClient({ promptCaching: false });
+        const options = await convertToBamlClientOptions(client);
+        const agent = new Agent({ llm: client, actions: [], telemetry: false });
+
+        expect(options).not.toHaveProperty('allowed_role_metadata');
+        expect(memoryPromptCaching(agent)).toBe(false);
+        expect(client.options.promptCaching).toBe(false);
+    });
+
+    test('enables cache-aware memory by default', async () => {
+        const client = openRouterClient();
+        const agent = new Agent({ llm: client, actions: [], telemetry: false });
+
+        expect(memoryPromptCaching(agent)).toBe(true);
+        expect(client.options.promptCaching).toBe(true);
+    });
+
+    test('keeps shared memory caching enabled when any model uses it', async () => {
+        const enabled: LLMClient = {
+            provider: 'anthropic',
+            options: { model: 'claude-sonnet-4', promptCaching: true },
+            roles: ['act'],
+        };
+        const disabled: LLMClient = {
+            ...openRouterClient({ promptCaching: false }),
+            roles: ['extract', 'query'],
+        };
+
+        for (const llms of [[enabled, disabled], [disabled, enabled]]) {
+            const agent = new Agent({ llm: llms, actions: [], telemetry: false });
+            expect(memoryPromptCaching(agent)).toBe(true);
+        }
+    });
+});
+
+describe('OpenRouter usage accounting', () => {
+    test('separates uncached, cache-read, and cache-write input tokens', async () => {
+        const usage = reportUsage(
+            openRouterClient(),
+            {
+                usage: {
+                    prompt_tokens: 1_000,
+                    completion_tokens: 50,
+                    prompt_tokens_details: {
+                        cached_tokens: 600,
+                        cache_write_tokens: 300,
+                    },
+                },
+            },
+            { inputTokens: 1_000, outputTokens: 50 },
+        );
+
+        expect(usage).toMatchObject({
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadInputTokens: 600,
+            cacheWriteInputTokens: 300,
+        });
+    });
+
+    test('clamps malformed cache components to the prompt total', async () => {
+        const usage = reportUsage(
+            openRouterClient(),
+            {
+                usage: {
+                    prompt_tokens: 100,
+                    completion_tokens: 10,
+                    prompt_tokens_details: {
+                        cached_tokens: 1_000,
+                        cache_write_tokens: 1_000,
+                    },
+                },
+            },
+            { inputTokens: 100, outputTokens: 10 },
+        );
+
+        expect(usage).toMatchObject({
+            inputTokens: 0,
+            outputTokens: 10,
+            cacheReadInputTokens: 100,
+        });
+        expect(usage).not.toHaveProperty('cacheWriteInputTokens');
+    });
+
+    test('falls back to collector totals when prompt details are unavailable', async () => {
+        const usage = reportUsage(
+            openRouterClient(),
+            { usage: { completion_tokens: 23 } },
+            { inputTokens: 400, outputTokens: 23 },
+        );
+
+        expect(usage).toMatchObject({ inputTokens: 400, outputTokens: 23 });
+        expect(usage).not.toHaveProperty('cacheReadInputTokens');
+        expect(usage).not.toHaveProperty('cacheWriteInputTokens');
+    });
+
+    test('keeps collector fallback deltas aligned after a cached response', async () => {
+        const harness = new ModelHarness({ llm: openRouterClient() });
+        const reported: ModelUsage[] = [];
+        harness.events.on('tokensUsed', (usage) => reported.push(usage));
+
+        setCollector(
+            harness,
+            {
+                usage: {
+                    prompt_tokens: 1_000,
+                    completion_tokens: 50,
+                    prompt_tokens_details: { cached_tokens: 600 },
+                },
+            },
+            { inputTokens: 1_000, outputTokens: 50 },
+        )._reportUsage();
+        setCollector(harness, {}, { inputTokens: 1_200, outputTokens: 60 })._reportUsage();
+
+        expect(reported[1]).toMatchObject({ inputTokens: 200, outputTokens: 10 });
+    });
+
+    test('preserves native Anthropic input-token semantics', async () => {
+        const usage = reportUsage(
+            {
+                provider: 'anthropic',
+                options: { model: 'claude-sonnet-4' },
+            },
+            {
+                usage: {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cache_creation_input_tokens: 300,
+                    cache_read_input_tokens: 600,
+                },
+            },
+            { inputTokens: 1_000, outputTokens: 50 },
+        );
+
+        expect(usage).toMatchObject({
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadInputTokens: 600,
+            cacheWriteInputTokens: 300,
+        });
+    });
+});

--- a/packages/magnitude-core/src/ai/types.ts
+++ b/packages/magnitude-core/src/ai/types.ts
@@ -95,7 +95,8 @@ export interface OpenAIGenericClient {
         baseUrl: string,
         apiKey?: string,
         temperature?: number,
-        headers?: Record<string, string>
+        headers?: Record<string, string>,
+        promptCaching?: boolean
     }
 }
 

--- a/packages/magnitude-core/src/ai/util.ts
+++ b/packages/magnitude-core/src/ai/util.ts
@@ -1,9 +1,15 @@
-import { type LLMClient } from '@/ai/types';
+import { type LLMClient, type OpenAIGenericClient } from '@/ai/types';
 import { Agent, AgentOptions } from "@/agent";
 import { BrowserConnector, BrowserConnectorOptions } from "@/connectors/browserConnector";
 import { completeClaudeCodeAuthFlow } from './claudeCode';
 
 function cleanNestedObject(obj: object): object {
+    if (Array.isArray(obj)) {
+        return obj
+            .filter((value) => value !== null && value !== undefined)
+            .map((value) => typeof value === 'object' ? cleanNestedObject(value) : value);
+    }
+
     // Remove null/undefined key values entirely
     return Object.fromEntries(
         Object.entries(obj)
@@ -15,6 +21,23 @@ function cleanNestedObject(obj: object): object {
                 typeof value === 'object' ? cleanNestedObject(value) : value
             ])
     );
+}
+
+export function isOpenRouterClaude(client: LLMClient): client is OpenAIGenericClient {
+    if (client.provider !== 'openai-generic' || !isClaude(client)) return false;
+    try {
+        const url = new URL(client.options.baseUrl);
+        return url.protocol === 'https:' &&
+            url.hostname.toLowerCase() === 'openrouter.ai' &&
+            url.port === '' &&
+            url.username === '' &&
+            url.password === '' &&
+            url.pathname.replace(/\/+$/, '') === '/api/v1' &&
+            url.search === '' &&
+            url.hash === '';
+    } catch {
+        return false;
+    }
 }
 
 export async function convertToBamlClientOptions(client: LLMClient): Promise<Record<string, any>> {
@@ -86,6 +109,7 @@ export async function convertToBamlClientOptions(client: LLMClient): Promise<Rec
             temperature: temp,
         };
     } else if (client.provider === 'openai-generic') {
+        const promptCaching = isOpenRouterClaude(client) && client.options.promptCaching !== false;
         options = {
             base_url: client.options.baseUrl,
             api_key: client.options.apiKey,
@@ -95,7 +119,8 @@ export async function convertToBamlClientOptions(client: LLMClient): Promise<Rec
                 "HTTP-Referer": "https://magnitude.run",
                 "X-Title": "Magnitude",
                 ...client.options.headers
-            }
+            },
+            ...(promptCaching ? { allowed_role_metadata: ["cache_control"] } : {})
         };
     } else if (client.provider === 'azure-openai') {
         options = {


### PR DESCRIPTION
## Summary

- enable prompt caching by default for Claude models on the official OpenRouter API endpoint, with `promptCaching: false` as an opt-out
- forward BAML `cache_control` role metadata without changing prompt content or the existing four-breakpoint limit
- report OpenRouter uncached, cache-read, and cache-write input tokens while preserving native Anthropic accounting and cumulative fallbacks

Fixes #80.

## Performance

A deterministic five-turn prompt-cache harness reduced modeled uncached prompt tokens from `11,250` to `4,000` (`64.4%`). It verifies identical prompt content and order, cache-breakpoint limits, non-Claude and non-OpenRouter controls, endpoint spoofing controls, malformed usage clamping, native Anthropic behavior, and multi-model opt-out ordering before reporting the metric.

The direction was found by running autoresearch with Weco, then rebuilt as a focused patch and validated independently: [public trajectory](https://dashboard.weco.ai/share/Oj1P6pXBr0gxSWfk4X_D1Y2AdB9l8Ujn).

## Validation

- `bun test packages/magnitude-core/src --timeout 15000` (`46 passed`)
- `cd packages/magnitude-core && bun run check`
- `bun run build`
- strict evaluator: `prompt_cache_uncached_input_tokens=4000`
- `git diff --check`
