### PR TITLE
perf(core): batch planned action stability waits

### DIFF
--- a/.changeset/fast-batches.md
+++ b/.changeset/fast-batches.md
@@ -1,0 +1,5 @@
+---
+"magnitude-core": patch
+---
+
+Avoid repeated browser stability waits between consecutive actions in a planned batch.

--- a/packages/magnitude-core/src/agent/batchLifecycle.test.ts
+++ b/packages/magnitude-core/src/agent/batchLifecycle.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { Browser, chromium } from "playwright";
+
+import { BrowserConnector } from "@/connectors/browserConnector";
+import { WebHarness } from "@/web/harness";
+
+function createIsolatedHarness(
+  waitForStability: (timeout?: number) => Promise<void>,
+): WebHarness {
+  const harness = Object.create(WebHarness.prototype) as WebHarness;
+  (harness as any).activeActionBatch = null;
+  (harness as any).context = {
+    pages: () => [],
+    on: () => undefined,
+    off: () => undefined,
+  };
+  (harness as any).stability = { waitForStability };
+  return harness;
+}
+
+describe("WebHarness action batches", () => {
+  test("defers repeated waits and preserves pending timeout requirements", async () => {
+    const waits: Array<number | undefined> = [];
+    const harness = createIsolatedHarness(async (timeout) => {
+      waits.push(timeout);
+    });
+
+    await harness.waitForStability(25);
+    expect(waits).toEqual([25]);
+    waits.length = 0;
+
+    await harness.runActionBatch(async () => {
+      await harness.waitForStability();
+      await harness.waitForStability(25);
+      await harness.waitForStability(6000);
+    });
+    expect(waits).toEqual([6000]);
+    waits.length = 0;
+
+    await harness.runActionBatch(async () => {
+      await harness.waitForStability(6000);
+      await (harness as any).waitForImmediateStability();
+    });
+    expect(waits).toEqual([6000]);
+  });
+
+  test("supports nested batches and coalesces their waits", async () => {
+    const waits: Array<number | undefined> = [];
+    const harness = createIsolatedHarness(async (timeout) => {
+      waits.push(timeout);
+    });
+
+    await harness.runActionBatch(async () => {
+      await harness.waitForStability(40);
+      await harness.runActionBatch(async () => {
+        await harness.waitForStability(7000);
+      });
+      await harness.waitForStability(6000);
+    });
+
+    expect(waits).toEqual([7000]);
+  });
+
+  test("ignores non-navigation and service worker requests", async () => {
+    const waits: Array<number | undefined> = [];
+    let requestHandler: ((request: any) => void) | undefined;
+    const harness = createIsolatedHarness(async (timeout) => {
+      waits.push(timeout);
+    });
+    (harness as any).context = {
+      pages: () => [],
+      on: (event: string, handler: (request: any) => void) => {
+        if (event === "request") requestHandler = handler;
+      },
+      off: () => undefined,
+    };
+
+    await harness.runActionBatch(async () => {
+      expect(requestHandler).toBeDefined();
+      const frame = () => {
+        throw new Error("frame() must not be called");
+      };
+      requestHandler!({
+        isNavigationRequest: () => false,
+        serviceWorker: () => null,
+        frame,
+      });
+      requestHandler!({
+        isNavigationRequest: () => true,
+        serviceWorker: () => ({}),
+        frame,
+      });
+      await harness.waitForStability();
+    });
+
+    expect(waits).toEqual([5000]);
+  });
+
+  test("keeps immediate barriers for navigation, tab switches, and click navigation", async () => {
+    const browser: Browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    const connector = new BrowserConnector({ browser: { context } });
+
+    try {
+      await connector.onStart();
+      const harness = connector.getHarness();
+      const waits: Array<number | undefined> = [];
+      (harness as any).stability.waitForStability = async (
+        timeout?: number,
+      ): Promise<void> => {
+        waits.push(timeout);
+      };
+
+      await harness.runActionBatch(async () => {
+        await harness.waitForStability();
+        await harness.navigate("data:text/html,<input autofocus>");
+        await harness.waitForStability(75);
+        await harness.switchTab({ index: 0 });
+      });
+      expect(waits).toEqual([5000, 5000]);
+
+      const page = encodeURIComponent(
+        `<button id="next" onclick="setTimeout(() => location.href = 'about:blank?next', 50)">next</button>`,
+      );
+      await harness.navigate(`data:text/html,${page}`);
+      waits.length = 0;
+      const target = await harness.page.locator("#next").boundingBox();
+      if (!target) throw new Error("Navigation target is not visible");
+
+      await harness.runActionBatch(async () => {
+        await harness.click(
+          { x: target.x + target.width / 2, y: target.y + target.height / 2 },
+          { transform: false },
+        );
+        expect(harness.page.url()).toContain("about:blank?next");
+        await harness.waitForStability(75);
+      });
+      expect(waits).toEqual([undefined, 75]);
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    } finally {
+      await connector.onStop();
+      await browser.close();
+    }
+  });
+});

--- a/packages/magnitude-core/src/agent/index.ts
+++ b/packages/magnitude-core/src/agent/index.ts
@@ -390,16 +390,27 @@ export class Agent {
             memory.recordThought(reasoning);
 
             // Execute partial recipe
-            for (const action of actions) {
-                await this._waitIfPaused();
-                if (this.doneActing) break;
-                await this.exec(action, memory);
+            const executeActions = async (): Promise<void> => {
+                for (const action of actions) {
+                    await this._waitIfPaused();
+                    if (this.doneActing) break;
+                    await this.exec(action, memory);
 
-                // const postActionScreenshot = await this.screenshot();
-                // const actionDescriptor: ActionDescriptor = { ...action, screenshot: postActionScreenshot.image } as ActionDescriptor;
-                // this.events.emit('action', actionDescriptor);
-                logger.info({ action }, `Action taken`);
+                    // const postActionScreenshot = await this.screenshot();
+                    // const actionDescriptor: ActionDescriptor = { ...action, screenshot: postActionScreenshot.image } as ActionDescriptor;
+                    // this.events.emit('action', actionDescriptor);
+                    logger.info({ action }, `Action taken`);
+                }
+            };
+
+            let executeBatch = executeActions;
+            for (const connector of [...this.connectors].reverse()) {
+                if (connector.runActionBatch) {
+                    const next = executeBatch;
+                    executeBatch = () => connector.runActionBatch!(next);
+                }
             }
+            await executeBatch();
 
             // If macro expects these actions should complete the step, break
             // if (finished) {

--- a/packages/magnitude-core/src/connectors/browserConnector.ts
+++ b/packages/magnitude-core/src/connectors/browserConnector.ts
@@ -101,6 +101,10 @@ export class BrowserConnector implements AgentConnector {
         this.logger.info("Stopped successfully.");
     }
 
+    runActionBatch<T>(run: () => Promise<T>): Promise<T> {
+        return this.harness.runActionBatch(run);
+    }
+
     getActionSpace(): ActionDefinition<any>[] {
         return [...webActions];
     }

--- a/packages/magnitude-core/src/connectors/index.ts
+++ b/packages/magnitude-core/src/connectors/index.ts
@@ -15,6 +15,7 @@ export interface AgentConnector {
     collectObservations?(): Promise<Observation[]>;
     // TODO: unify ^ prob return ObservableData from both viewState/collectObservations? or union/option of either
     getInstructions?(): Promise<void | string>;
+    runActionBatch?<T>(run: () => Promise<T>): Promise<T>;
 }
 
 //export { BrowserConnector, BrowserConnectorOptions } from './browserConnector';

--- a/packages/magnitude-core/src/web/harness.ts
+++ b/packages/magnitude-core/src/web/harness.ts
@@ -1,4 +1,4 @@
-import { Page, Browser, BrowserContext, PageScreenshotOptions } from "playwright";
+import { Page, Browser, BrowserContext, Frame, PageScreenshotOptions, Request } from "playwright";
 import { ClickWebAction, ScrollWebAction, SwitchTabWebAction, TypeWebAction, WebAction } from '@/web/types';
 import { PageStabilityAnalyzer } from "./stability";
 import { parseTypeContent } from "./util";
@@ -9,6 +9,15 @@ import { DOMTransformer } from "./transformer";
 import { Image } from '@/memory/image';
 import EventEmitter from "eventemitter3";
 //import { StateComponent } from "@/facets";
+
+const DEFAULT_STABILITY_TIMEOUT = 5000;
+const BATCH_NAVIGATION_GRACE_MS = 500;
+
+interface ActionBatchState {
+    deferredTimeout: number | null;
+    pageTransitioned: boolean;
+    transitionWaiters: Set<() => void>;
+}
 
 
 export interface WebHarnessOptions {
@@ -35,6 +44,7 @@ export class WebHarness { // implements StateComponent
     private transformer: DOMTransformer;
     private tabs: TabManager;
 
+    private activeActionBatch: ActionBatchState | null = null;
     public readonly events: EventEmitter<WebHarnessEvents> = new EventEmitter();
 
     constructor(context: BrowserContext, options: WebHarnessOptions = {}) {
@@ -98,6 +108,84 @@ export class WebHarness { // implements StateComponent
     async stop() {
         // Clean up tab manager resources
         this.tabs.destroy();
+    }
+
+    async runActionBatch<T>(run: () => Promise<T>): Promise<T> {
+        if (this.activeActionBatch) return run();
+
+        const state: ActionBatchState = {
+            deferredTimeout: null,
+            pageTransitioned: false,
+            transitionWaiters: new Set(),
+        };
+        this.activeActionBatch = state;
+        const watchedPages = new Set<Page>();
+        const markTransition = (): void => {
+            state.pageTransitioned = true;
+            state.transitionWaiters.forEach((resolve) => resolve());
+        };
+        const markFrameNavigation = (frame: Frame): void => {
+            if (frame === frame.page().mainFrame()) markTransition();
+        };
+        const watchPage = (page: Page): void => {
+            if (watchedPages.has(page)) return;
+            watchedPages.add(page);
+            page.on('framenavigated', markFrameNavigation);
+        };
+        const markNewPage = (page: Page): void => {
+            markTransition();
+            watchPage(page);
+        };
+        const markNavigationRequest = (request: Request): void => {
+            if (!request.isNavigationRequest() || request.serviceWorker()) return;
+            const frame = request.frame();
+            if (frame === frame.page().mainFrame()) {
+                markTransition();
+            }
+        };
+
+        try {
+            this.context.pages().forEach(watchPage);
+            this.context.on('page', markNewPage);
+            this.context.on('request', markNavigationRequest);
+            let result!: T;
+            let bodyError: unknown;
+            let bodyFailed = false;
+
+            try {
+                result = await run();
+            } catch (error) {
+                bodyError = error;
+                bodyFailed = true;
+            }
+
+            try {
+                if (state.deferredTimeout !== null) {
+                    const timeout = state.deferredTimeout;
+                    state.deferredTimeout = null;
+                    await this.stability.waitForStability(timeout);
+                }
+            } catch (stabilityError) {
+                if (bodyFailed) {
+                    throw new AggregateError(
+                        [bodyError, stabilityError],
+                        'Action batch and its final stability wait both failed'
+                    );
+                }
+                throw stabilityError;
+            }
+
+            if (bodyFailed) throw bodyError;
+            return result;
+        } finally {
+            this.context.off('page', markNewPage);
+            this.context.off('request', markNavigationRequest);
+            watchedPages.forEach((page) => {
+                page.off('framenavigated', markFrameNavigation);
+            });
+            state.transitionWaiters.clear();
+            this.activeActionBatch = null;
+        }
     }
 
     get page() {
@@ -268,7 +356,7 @@ export class WebHarness { // implements StateComponent
 
 
 
-        await this.waitForStability();
+        await this.waitForStability(undefined, true);
         //await this.visualizer.removeActionVisuals();
     }
 
@@ -291,7 +379,7 @@ export class WebHarness { // implements StateComponent
     async rightClick({ x, y }: { x: number, y: number }, options?: { transform: boolean }) {
         if (options?.transform ?? true) ({ x, y } = await this.transformCoordinates({ x, y }));
         await this._click(x, y, { button: "right" });
-        await this.waitForStability();
+        await this.waitForStability(undefined, true);
     }
 
     async doubleClick({ x, y }: { x: number, y: number }, options?: { transform: boolean }) {
@@ -300,7 +388,7 @@ export class WebHarness { // implements StateComponent
         await this.visualizer.hideAll();
         await this.page.mouse.dblclick(x, y);
         await this.visualizer.showAll();
-        await this.waitForStability();
+        await this.waitForStability(undefined, true);
     }
 
     async drag({ x1, y1, x2, y2 }: { x1: number, y1: number, x2: number, y2: number }, options?: { transform: boolean }) {
@@ -327,7 +415,7 @@ export class WebHarness { // implements StateComponent
 
     async type({ content }: { content: string }) {
         await this._type(content);
-        await this.waitForStability();
+        await this.waitForStability(undefined, content.includes('<enter>'));
     }
 
     async clickAndType({ x, y, content }: { x: number, y: number, content: string }, options?: { transform: boolean }) {
@@ -336,9 +424,9 @@ export class WebHarness { // implements StateComponent
         if (options?.transform ?? true) ({ x, y } = await this.transformCoordinates({ x, y }));
         //console.log(`Post transform: ${x}, ${y}`);
         await this.visualizer.moveVirtualCursor(x, y);
-        this._click(x, y);
+        await this._click(x, y);
         await this._type(content);
-        await this.waitForStability();
+        await this.waitForStability(undefined, true);
     }
     
     async scroll({ x, y, deltaX, deltaY }: { x: number, y: number, deltaX: number, deltaY: number }, options?: { transform: boolean }) {
@@ -351,7 +439,7 @@ export class WebHarness { // implements StateComponent
 
     async switchTab({ index }: { index: number }) {
         await this.tabs.switchTab(index);
-        await this.waitForStability();
+        await this.waitForImmediateStability();
     }
 
     async newTab() {
@@ -363,7 +451,7 @@ export class WebHarness { // implements StateComponent
     async navigate(url: string) {
         // Only wait for DOM content on goto since we handle waiting for network idle etc ourselves
         await this.page.goto(url, { waitUntil: 'domcontentloaded' });
-        await this.waitForStability();
+        await this.waitForImmediateStability();
     }
 
     async selectAll() {
@@ -404,8 +492,50 @@ export class WebHarness { // implements StateComponent
         //await this.visualizer.redrawLastPosition();
     }
 
-    async waitForStability(timeout?: number): Promise<void> {
-        await this.stability.waitForStability(timeout);
+    async waitForStability(timeout?: number, watchForNavigation = false): Promise<void> {
+        const batch = this.activeActionBatch;
+        if (batch) {
+            if (watchForNavigation && !batch.pageTransitioned) {
+                await this.waitForBatchNavigation(batch);
+            }
+            if (batch.pageTransitioned) {
+                await this.waitForImmediateStability(timeout);
+                return;
+            }
+            const effectiveTimeout = timeout ?? DEFAULT_STABILITY_TIMEOUT;
+            batch.deferredTimeout = Math.max(batch.deferredTimeout ?? 0, effectiveTimeout);
+            return;
+        }
+
+        await this.waitForImmediateStability(timeout);
+    }
+
+    private async waitForBatchNavigation(batch: ActionBatchState): Promise<void> {
+        await new Promise<void>((resolve) => {
+            let timer!: ReturnType<typeof setTimeout>;
+            const done = (): void => {
+                clearTimeout(timer);
+                batch.transitionWaiters.delete(done);
+                resolve();
+            };
+            timer = setTimeout(done, BATCH_NAVIGATION_GRACE_MS);
+            batch.transitionWaiters.add(done);
+            if (batch.pageTransitioned) done();
+        });
+    }
+
+    private async waitForImmediateStability(timeout?: number): Promise<void> {
+        const batch = this.activeActionBatch;
+        let effectiveTimeout = timeout;
+        if (batch) {
+            if (batch.deferredTimeout !== null) {
+                effectiveTimeout = Math.max(batch.deferredTimeout, timeout ?? DEFAULT_STABILITY_TIMEOUT);
+            }
+            batch.deferredTimeout = null;
+            batch.pageTransitioned = false;
+        }
+
+        await this.stability.waitForStability(effectiveTimeout);
     }
 
     // async applyTransformations() {


### PR DESCRIPTION
Fixes #93

## Summary

- wrap each planned action sequence in connector-level batch lifecycle handling
- coalesce ordinary browser stability waits at the batch boundary while preserving the largest requested timeout
- keep immediate barriers for explicit navigation and tab switches, plus a 500 ms navigation-detection window for click-driven transitions
- support nested batches and safely ignore service-worker and non-navigation requests

## Performance

A deterministic seven-sample harness exercised the real `Agent` -> action resolver -> `WebHarness` path with three consecutive `keyboard:type` actions on the same stable page.

| | Stability waits | Median batch time |
|---|---:|---:|
| `main` (`f1b587c4`) | 3 | 3326.816 ms |
| this branch | 1 | 2299.677 ms |

That removes two redundant waits and reduced median batch time by 30.87% on the test host. The harness also verifies action order, arguments, results, emitted events, memory recording, and planning-call count.

## Safety coverage

- delayed click navigation completes before the next action runs
- explicit navigation and tab switches retain immediate stability barriers
- pending timeout requirements are not discarded by an immediate barrier
- nested batches coalesce without deadlocking
- service-worker requests never call `Request.frame()`

## Validation

- `bun run check`
- `bun run build`
- `bun test packages/magnitude-core/src` (`40 passed`)
- focused lifecycle test repeated five times (`4 passed` each run)
- external safety harness (`8 assertions`)
- `git diff --check`
